### PR TITLE
Add npm start script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ This repository contains a minimal Salesforce DX project with a simple Lightning
 - `sfdx-project.json` – SFDX project configuration.
 - `force-app/main/default/lwc/helloWorld` – Simple **Hello World** Lightning Web Component.
 
+### Local Development Server
+
+Run the lightweight LWC app locally using:
+
+```bash
+npm start
+```
+
 ### GitHub Pages Deployment
 
 The repository also includes a lightweight LWC Open Source app in the `src` folder. Use the commands below to build it to the `docs/` directory so it can be hosted using GitHub Pages:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "scripts": {
+    "start": "lwc-services serve",
     "build": "lwc-services build -d docs"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add `start` script using `lwc-services serve`
- document how to run the local development server

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859363938ac8326b213d003d1ee15bb