### PR TITLE
Add landing page for GitHub Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ docs/*
 !docs/segment-review.html
 !docs/campaign-form.html
 !docs/campaign-form.js
+!docs/index.html

--- a/README.md
+++ b/README.md
@@ -39,3 +39,12 @@ NODE_OPTIONS=--openssl-legacy-provider npm run build
 This command creates the `docs/` folder locally, but you do **not** need to
 commit it. The workflow will handle building and deploying to GitHub Pages for
 you.
+
+The GitHub Pages site is served from the `docs/` directory. The `index.html`
+file in that folder acts as a small landing page with links to the example
+pages:
+
+- `campaign-form.html` – basic campaign creation form
+- `segment-review.html` – sample supplier review table
+
+Open `index.html` after the site is deployed to navigate to these examples.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Demo Pages</title>
+  <link rel="stylesheet" href="https://unpkg.com/@salesforce-ux/design-system/assets/styles/salesforce-lightning-design-system.min.css">
+</head>
+<body class="slds-p-around_medium">
+  <div class="slds-card">
+    <div class="slds-card__body slds-p-around_medium">
+      <h1 class="slds-text-heading_large slds-m-bottom_medium">Demo Pages</h1>
+      <ul class="slds-list_dotted">
+        <li><a href="campaign-form.html">Campaign Creation Form</a></li>
+        <li><a href="segment-review.html">Supplier Review</a></li>
+      </ul>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `docs/index.html` as a simple landing page linking to existing demo pages
- track the new page in `.gitignore`
- document the landing page in README

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68595cac51f083269ccb897d89bc85d0